### PR TITLE
Need to stop Sendmail

### DIFF
--- a/modules/clean-packages.sh
+++ b/modules/clean-packages.sh
@@ -10,6 +10,12 @@ if ! (question --default yes "Do you still want to run this module and purge all
 	continue
 fi
 
+# Stopping Sendmail daemon
+if check_package "sendmail"; then
+	subheader "Stopping Sendmail daemon..."
+	daemon_manage sendmail stop
+fi
+
 # Update Package Lists
 subheader "Updating Package Lists..."
 package_update


### PR DESCRIPTION
Need to stop Sendmail, if not, it can screw up the exim4 installation, as the apt-get command doesn't shut down sendmail and sendmail keeps running and binding to port 25 and exim4 can go crazy.
