### PR TITLE
FastCGI - Only set 'HTTPS' if not empty

### DIFF
--- a/modules/http-install-nginx/nginx/fastcgi_params
+++ b/modules/http-install-nginx/nginx/fastcgi_params
@@ -5,7 +5,7 @@ fastcgi_param CONTENT_TYPE $content_type;
 fastcgi_param DOCUMENT_ROOT $document_root;
 fastcgi_param DOCUMENT_URI $document_uri;
 fastcgi_param GATEWAY_INTERFACE CGI/1.1;
-fastcgi_param HTTPS  $https;
+fastcgi_param HTTPS $https if_not_empty;
 fastcgi_param QUERY_STRING $query_string;
 fastcgi_param REDIRECT_STATUS 200;
 fastcgi_param REMOTE_ADDR $remote_addr;


### PR DESCRIPTION
The current setup sets 'HTTPS' as an empty string which I've found to clash with a couple frameworks/CMS'.

This simply sets 'HTTPS' **only** if SSL is found... Which also aligns with the default Apache behaviour.
